### PR TITLE
docs: define stitch asset lifecycle policy

### DIFF
--- a/docs/manual-validation.md
+++ b/docs/manual-validation.md
@@ -3,7 +3,13 @@
 ## Scope
 - Change: `astro-landing-page`
 - Goal: close remaining verify warnings without build/test-framework overreach
-- Reference artifacts: `stitch/code.html`, `stitch/screen.png`, `stitch/DESIGN.md`
+- Lifecycle policy / source of truth: `stitch/README.md`
+- Landing manual-reference artifacts: `stitch/code.html`, `stitch/screen.png`, `stitch/DESIGN.md`
+
+## Stitch authority
+- `stitch/README.md` is the canonical lifecycle policy for manual-reference authority and bundle status.
+- The landing bundle in `stitch/` is the active manual-reference source for `/` review in this document.
+- Stitch assets are human/manual references only; automated visual baselines live under `tests/visual/__screenshots__/`.
 
 ## Structural / visual pass
 - Reviewed current Astro section order against `stitch/code.html`: header → hero → problem → features → code demo → use cases → CTA → footer.

--- a/stitch/README.md
+++ b/stitch/README.md
@@ -1,0 +1,48 @@
+# Stitch lifecycle policy
+
+## Purpose
+
+`stitch/` is the project source of truth for **human/manual reference bundles** only. Nothing under this directory is an approved automated regression baseline.
+
+## Lifecycle states
+
+| State | Meaning | Allowed usage |
+|---|---|---|
+| `active manual reference` | Current manual reference bundle for a live route/page. | Human review, design comparison, implementation handoff. |
+| `historical manual reference` | Retained bundle from an older or inactive route state. | Traceability only; do not treat as current authority for new work. |
+| `automated baseline` | Approved visual-regression artifact used by tests. | Only files under `tests/visual/__screenshots__/`. |
+
+## Authority boundary
+
+- `stitch/` contains manual reference material such as captured HTML, screenshots, and design notes for humans.
+- `tests/visual/__screenshots__/` contains the approved automated baselines consumed by Playwright visual tests.
+- `stitch/*.png`, `stitch/**/*.png`, and any other asset under `stitch/` are **never** automated baselines.
+- If manual-reference guidance and test-baseline guidance appear to conflict, `stitch/README.md` defines Stitch authority and `tests/visual/README.md` defines baseline/test workflow.
+
+## Inventory and current status
+
+| Bundle | Route scope | Status | Assets | Authority notes |
+|---|---|---|---|---|
+| `stitch/` | `/` landing page | `active manual reference` | `stitch/code.html`, `stitch/screen.png`, `stitch/DESIGN.md` | Current human-review bundle for landing implementation and manual validation. |
+| `stitch/pricing/` | `/pricing` | `historical manual reference` | `stitch/pricing/code.html`, `stitch/pricing/screen.png`, `stitch/pricing/DESIGN.md` | Retained for traceability/manual context only; not active authority unless explicitly reactivated in a future change. |
+
+## Pricing reactivation rule
+
+`stitch/pricing/` stays historical/manual-only until a future change **explicitly** reactivates it. Any such change must, in the same diff:
+
+1. update the inventory table in this file,
+2. update downstream docs that point to Stitch authority (`docs/manual-validation.md`, `tests/visual/README.md`, and any new related docs), and
+3. keep the authority boundary clear between manual references and automated baselines.
+
+Until those updates happen together, `stitch/pricing/` must not be treated as active manual authority.
+
+## Path preservation for this policy change
+
+This lifecycle-policy change is documentation-only. It does **not** move, rename, delete, or regenerate Stitch assets. The expected preserved paths are:
+
+- `stitch/code.html`
+- `stitch/screen.png`
+- `stitch/DESIGN.md`
+- `stitch/pricing/code.html`
+- `stitch/pricing/screen.png`
+- `stitch/pricing/DESIGN.md`

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -14,7 +14,9 @@ Esta capa cubre screenshots full-page de escritorio para `/` y `/pricing` con Pl
 - Sólo Chromium.
 - Sólo desktop.
 - Sólo `/` y `/pricing`.
-- No usa `stitch/*.png` como baseline automatizado; esas imágenes quedan como referencia manual.
+- `stitch/README.md` es la política fuente para autoridad y estado de los bundles manuales de `stitch/`.
+- No usa `stitch/*.png` ni ningún asset dentro de `stitch/` como baseline automatizado; esos archivos quedan como referencia manual.
+- Los únicos baselines automatizados aprobados viven en `tests/visual/__screenshots__/`.
 
 ## Guardrails de determinismo
 


### PR DESCRIPTION
Closes #12

## Summary
- define a low-risk lifecycle policy for Stitch design handoff assets without moving or renaming any files
- document the authority split between human design references in `stitch/` and automated visual baselines in `tests/visual/__screenshots__/`
- align manual validation and visual test docs with the new Stitch policy and inventory

## Changes
| File | Change |
|------|--------|
| `stitch/README.md` | Added the Stitch lifecycle policy, inventory, authority model, and reactivation rules |
| `docs/manual-validation.md` | Linked manual review guidance to the Stitch policy and inventory |
| `tests/visual/README.md` | Clarified that Stitch PNGs are reference inputs, not automated baselines |

## Test Plan
- [x] Verified the documented Stitch paths still exist without moves or renames
- [x] Reviewed `stitch/README.md`, `docs/manual-validation.md`, and `tests/visual/README.md` for terminology alignment
- [x] Confirmed automated baselines remain under `tests/visual/__screenshots__/`